### PR TITLE
Fix compilation issues on modern C compiler and minor bug fixes.

### DIFF
--- a/progs/iter.c
+++ b/progs/iter.c
@@ -76,7 +76,7 @@ void usage(int argc, char* argv[])
   printf("        this help\n");
   printf("  MATRIX OPTIONS:\n");
   printf("        -hb  filename    (matrix from Harwell-Boeing file)\n");
-  rintf("        -ijv ijvfilename (matrix from file)\n");
+  printf("        -ijv ijvfilename (matrix from file)\n");
   printf("        -mtx mtxfilename (matrix from file)\n");
   printf("        -ccs ccsfilename (matrix from file)\n");
   printf("        -discont     X Y Z jump (X-by-Y-by-Z poisson with discontinuous coeff.)\n");

--- a/progs/iter.c
+++ b/progs/iter.c
@@ -76,7 +76,7 @@ void usage(int argc, char* argv[])
   printf("        this help\n");
   printf("  MATRIX OPTIONS:\n");
   printf("        -hb  filename    (matrix from Harwell-Boeing file)\n");
-  printf("        -ijv ijvfilename (matrix from file)\n");
+  rintf("        -ijv ijvfilename (matrix from file)\n");
   printf("        -mtx mtxfilename (matrix from file)\n");
   printf("        -ccs ccsfilename (matrix from file)\n");
   printf("        -discont     X Y Z jump (X-by-Y-by-Z poisson with discontinuous coeff.)\n");
@@ -375,8 +375,9 @@ int main(int argc, char* argv[])
 
     if (!strcmp(argv[i],"-mtx") && i <= argc-1) {
       i++;
+      // assume TAUCS_DOUBLE type. mtx loading doesn't automatically get this and it is not a user input.
       taucs_printf("main: reading mtx matrix %s\n",argv[i]);
-      A = taucs_ccs_read_mtx (argv[i],TAUCS_SYMMETRIC);
+      A = taucs_ccs_read_mtx (argv[i],TAUCS_SYMMETRIC | TAUCS_DOUBLE);
       taucs_printf("main: done reading\n");
     }
 

--- a/progs/taucs_cilk_test.c
+++ b/progs/taucs_cilk_test.c
@@ -6,7 +6,7 @@
 #include <stdio.h> 
 #include <stdlib.h> 
 
-#ifdef TAUCS_NO_CILK
+#ifndef TAUCS_WITH_CILK
 int main(void){
   printf("\n\n No Cilk in build, skipping test.\n");
   return 0;

--- a/progs/taucs_cilk_test.c
+++ b/progs/taucs_cilk_test.c
@@ -5,6 +5,14 @@
 
 #include <stdio.h> 
 #include <stdlib.h> 
+
+#ifdef TAUCS_NO_CILK
+int main(void){
+  printf("\n\n No Cilk in build, skipping test.\n");
+  return 0;
+}
+#else
+
 #include <cilk.h> 
 
 #pragma lang -C
@@ -39,3 +47,4 @@ cilk int main(int argc, char* argv[])
 
   return 0;
 }
+#endif

--- a/src/taucs.h
+++ b/src/taucs.h
@@ -3,6 +3,37 @@
 /* Author: Sivan Toledo                                  */
 /*********************************************************/
 
+#include <unistd.h>
+/* ---- Disable Cilk everywhere ---- */
+#ifndef TAUCS_WITH_CILK
+/* don’t include any Cilk headers */
+#undef TAUCS_C99_COMPLEX /* old comment said cilk2c can’t process complex.h */
+
+/* turn Cilk keywords into no-ops */
+#ifndef cilk
+#define cilk
+#endif
+#ifndef spawn
+#define spawn
+#endif
+#ifndef sync
+#define sync
+#endif
+
+/* map all taucs_cilk* tokens to plain versions */
+#ifndef taucs_cilk
+#define taucs_cilk
+#endif
+
+/* some files refer to cilk-lib; make those harmless */
+#ifndef __CILKRTS_ABI_VERSION
+#define __CILKRTS_ABI_VERSION 0
+#endif
+#else
+#include <cilk-lib.h>
+#include <cilk.h>
+#endif
+/* ---- end Cilk disable ---- */
 #include <taucs_config_tests.h>
 #include <taucs_config_build.h>
 

--- a/src/taucs_ccs_io.c
+++ b/src/taucs_ccs_io.c
@@ -642,6 +642,7 @@ taucs_dtl(ccs_read_mtx)(char* filename,int flags)
 
   if (fscanf(f, "%d %d %d", &nrows, &ncols, &nnz) != 3) {
     taucs_printf("taucs_ccs_read_mtx: wrong header\n");
+    printf("tauc_ccs_read_mtx: taucs excepts first line to be:\n<num_rows> <num_cols> <nnz>\n");
     return NULL;
   }
 


### PR DESCRIPTION
This PR updates TauCS to compile and run on modern systems. It also includes a few minor bug fixes.

Tested on Linux with GCC using the following compile command.
```
make CONFIG=linux.mk \
     LDFLAGS="-L/path/to/metis-4.0.3/lib" \
     CFLAGS="-I/path/to/metis-4.0.3/include" \
     LIBS="-lmetis -llapack -lblas -lgfortran -lm"
```

## Changes
- Disabled deprecated Cilk support by default (can be re-enabled with TAUCS_WITH_CILK flag)
- Added verbose description of reason for failure when mtx is wrong format
- Update -mtx in progs/iter.c to automatically assume DOUBLE precision instead of passing no type and failing silently.